### PR TITLE
[CAD-1462] Clarify insert ticker command name and report error if ticker already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Currently, the SMASH service works by allowing superusers to insert the ticker n
 
 There is a CLI utility for doing exactly that. If you want to reserve the ticker name "SALAD" for the specific metadata hash "2560993cf1b6f3f1ebde429f062ce48751ed6551c2629ce62e4e169f140a3524", then you would reserve it like this:
 ```
-SMASHPGPASSFILE=config/pgpass stack run smash-exe -- insert-ticker-name --tickerName "SALAD" --poolhash "2560993cf1b6f3f1ebde429f062ce48751ed6551c2629ce62e4e169f140a3524"
+SMASHPGPASSFILE=config/pgpass stack run smash-exe -- reserve-ticker-name --tickerName "SALAD" --poolhash "2560993cf1b6f3f1ebde429f062ce48751ed6551c2629ce62e4e169f140a3524"
 ```
 
 If somebody adds the ticker name that exists there, it will not be returned, but it will return 404.

--- a/src/Cardano/Db/Error.hs
+++ b/src/Cardano/Db/Error.hs
@@ -25,6 +25,7 @@ data DBFail
   | PoolDelisted
   | UnableToEncodePoolMetadataToJSON !Text
   | UnknownError !Text
+  | ReservedTickerAlreadyInserted !Text
   deriving (Eq, Show, Generic)
 
 {-
@@ -80,6 +81,11 @@ instance ToJSON DBFail where
             [ "code"            .= String "UnknownError"
             , "description"     .= String (renderLookupFail failure)
             ]
+    toJSON failure@(ReservedTickerAlreadyInserted _tickerName) =
+        object
+            [ "code"            .= String "ReservedTickerAlreadyInserted"
+            , "description"     .= String (renderLookupFail failure)
+            ]
 
 
 renderLookupFail :: DBFail -> Text
@@ -93,4 +99,5 @@ renderLookupFail lf =
     PoolDelisted -> "The pool has been delisted!"
     UnableToEncodePoolMetadataToJSON err -> "Unable to encode the content to JSON. " <> err
     UnknownError text -> "Unknown error. Context: " <> text
+    ReservedTickerAlreadyInserted tickerName -> "Ticker '" <> tickerName <> "' has already been inserted."
 

--- a/src/DB.hs
+++ b/src/DB.hs
@@ -131,9 +131,8 @@ postgresqlDataLayer = DataLayer
                 }
         return poolMetadataRefId
 
-    , dlAddReservedTicker = \tickerName poolMetadataHash -> do
-        reservedTickerId <- runDbAction Nothing $ insertReservedTicker $ ReservedTicker tickerName poolMetadataHash
-        return $ Right reservedTickerId
+    , dlAddReservedTicker = \tickerName poolMetadataHash ->
+        runDbAction Nothing $ insertReservedTicker $ ReservedTicker tickerName poolMetadataHash
 
     , dlCheckReservedTicker = \tickerName ->
         runDbAction Nothing $ queryReservedTicker tickerName
@@ -142,7 +141,7 @@ postgresqlDataLayer = DataLayer
         runDbAction Nothing $ queryDelistedPool poolId
 
     , dlAddDelistedPool  = \poolId -> do
-        _ <- runDbAction Nothing $ insertDelistedPool $ DelistedPool poolId
+        delistedPoolId <- runDbAction Nothing $ insertDelistedPool $ DelistedPool poolId
         return $ Right poolId
 
     , dlGetAdminUsers       = do


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-1462

Based on https://github.com/input-output-hk/smash/pull/45

Improvement reported by @dorin100 
Example:
```
$> SMASHPGPASSFILE=config/pgpass stack run smash-exe -- reserve-ticker-name --tickerName "EARTH" --poolhash "0bbae0287d0ee96cc63b07cc18d25483d9010282ac726c35f450ea8622036e87"
Reserving ticker name!
Adding reserved ticker 'EARTH' with hash: PoolMetadataHash {getPoolMetadataHash = "0bbae0287d0ee96cc63b07cc18d25483d9010282ac726c35f450ea8622036e87"}
Ticker name inserted into the database reserved!

$> SMASHPGPASSFILE=config/pgpass stack run smash-exe -- reserve-ticker-name --tickerName "EARTH" --poolhash "0bbae0287d0ee96cc63b07cc18d25483d9010282ac726c35f450ea8622036e87"
Reserving ticker name!
Adding reserved ticker 'EARTH' with hash: PoolMetadataHash {getPoolMetadataHash = "0bbae0287d0ee96cc63b07cc18d25483d9010282ac726c35f450ea8622036e87"}
Reserved ticker name not inserted! Ticker 'EARTH' has already been inserted.
```