### PR TITLE
[CAD-1744] Easily query reason for pool metadata lookup failure.

### DIFF
--- a/doc/getting-started/how-to-install-smash.md
+++ b/doc/getting-started/how-to-install-smash.md
@@ -284,4 +284,29 @@ curl -X GET -v http://localhost:3100/api/v1/metadata/062693863e0bcf9f619238f0207
 curl -X GET -v http://localhost:3100/api/v1/metadata/062693863e0bcf9f619238f020741381d4d3748aae6faf1c012e80e7/3b842358a698119a4b0c0f4934d26cff69190552bf47a85f40f5d1d646c82699 | jq .
 ```
 
-This assumes that you have a file called "test_pool.json" in your current directory that contains the JSON metadata for the stake pool.
+This assumes that you have a file called "test_pool.json" in your current directory that contains the JSON
+metadata for the stake pool.
+
+## Checking the pool rejection errors
+
+Currently there is a way to check if there are any errors while trying to download the pool metadata. It could be that the hash is wrong, that the server URL return 404, or something else.
+This is a nice way to check what went wrong.
+
+So if you want to see all the errors that were recorded, you can simply query:
+```
+http://localhost:3100/api/v1/errors
+```
+
+If you have a specific pool id you want to check, you can add that pool id (`c0b0e43213a8c898e373928fbfc3df81ee77c0df7dadc3ad6e5bae17`) in there:
+```
+http://localhost:3100/api/v1/errors?poolId=c0b0e43213a8c898e373928fbfc3df81ee77c0df7dadc3ad6e5bae17
+```
+
+The returned list consists of objects that contain:
+- time - the time formatted in `DD.MM.YYYY. HH:MM:SS` which I claim, is the only sane choice
+- utcTime - the time formatted in the standard UTCTime format for any clients
+- poolId - the pool id of the owner of the pool
+- poolHash - the hash of the pool metadata
+- cause - what is the cause of the error and why is it failing
+- retryCount - the number of times we retried to fetch the offline metadata
+

--- a/schema/migration-2-0002-20200904.sql
+++ b/schema/migration-2-0002-20200904.sql
@@ -1,0 +1,31 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 2 THEN
+    ALTER TABLE "pool_metadata_reference" ALTER COLUMN "pool_id" TYPE text;
+    ALTER TABLE "pool_metadata_reference" ALTER COLUMN "url" TYPE text;
+    ALTER TABLE "pool_metadata_reference" ALTER COLUMN "hash" TYPE text;
+    ALTER TABLE "pool_metadata" ALTER COLUMN "pool_id" TYPE text;
+    ALTER TABLE "pool_metadata" ALTER COLUMN "ticker_name" TYPE text;
+    ALTER TABLE "pool_metadata" ALTER COLUMN "hash" TYPE text;
+    ALTER TABLE "pool_metadata" ALTER COLUMN "metadata" TYPE text;
+    CREATe TABLE "pool_metadata_fetch_error"("id" SERIAL8  PRIMARY KEY UNIQUE,"fetch_time" timestamp NOT NULL,"pool_id" text NOT NULL,"pool_hash" text NOT NULL,"pmr_id" INT8 NOT NULL,"fetch_error" VARCHAR NOT NULL,"retry_count" uinteger NOT NULL);
+    ALTER TABLE "pool_metadata_fetch_error" ADD CONSTRAINT "unique_pool_metadata_fetch_error" UNIQUE("fetch_time","pool_id");
+    ALTER TABLE "pool_metadata_fetch_error" ADD CONSTRAINT "pool_metadata_fetch_error_pmr_id_fkey" FOREIGN KEY("pmr_id") REFERENCES "pool_metadata_reference"("id");
+    ALTER TABLE "delisted_pool" ALTER COLUMN "pool_id" TYPE text;
+    ALTER TABLE "reserved_ticker" ALTER COLUMN "name" TYPE text;
+    ALTER TABLE "reserved_ticker" ALTER COLUMN "pool_hash" TYPE text;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 2 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/smash.cabal
+++ b/smash.cabal
@@ -20,7 +20,7 @@ source-repository head
 
 Flag disable-basic-auth
   description:         Disable basic authentication scheme for other authentication mechanisms.
-  default:             True
+  default:             False
 
 library
 

--- a/src/Cardano/Db/Insert.hs
+++ b/src/Cardano/Db/Insert.hs
@@ -9,6 +9,7 @@ module Cardano.Db.Insert
   , insertReservedTicker
   , insertDelistedPool
   , insertAdminUser
+  , insertPoolMetadataFetchError
 
   -- Export mainly for testing.
   , insertByReturnKey
@@ -55,6 +56,12 @@ insertDelistedPool = insertByReturnKey
 
 insertAdminUser :: (MonadIO m) => AdminUser -> ReaderT SqlBackend m AdminUserId
 insertAdminUser = insertByReturnKey
+
+insertPoolMetadataFetchError
+    :: (MonadIO m)
+    => PoolMetadataFetchError
+    -> ReaderT SqlBackend m PoolMetadataFetchErrorId
+insertPoolMetadataFetchError = insertByReturnKey
 
 -------------------------------------------------------------------------------
 

--- a/src/Cardano/Db/Query.hs
+++ b/src/Cardano/Db/Query.hs
@@ -16,6 +16,7 @@ module Cardano.Db.Query
   , queryDelistedPool
   , queryReservedTicker
   , queryAdminUsers
+  , queryPoolMetadataFetchError
   ) where
 
 import           Cardano.Prelude            hiding (Meta, from, isJust,
@@ -153,6 +154,18 @@ queryAdminUsers :: MonadIO m => ReaderT SqlBackend m [AdminUser]
 queryAdminUsers = do
   res <- selectList [] []
   pure $ entityVal <$> res
+
+-- | Query all the errors we have.
+queryPoolMetadataFetchError :: MonadIO m => Maybe Types.PoolId -> ReaderT SqlBackend m [PoolMetadataFetchError]
+queryPoolMetadataFetchError Nothing = do
+  res <- selectList [] []
+  pure $ entityVal <$> res
+
+queryPoolMetadataFetchError (Just poolId) = do
+  res <- select . from $ \(poolMetadataFetchError :: SqlExpr (Entity PoolMetadataFetchError)) -> do
+            where_ (poolMetadataFetchError ^. PoolMetadataFetchErrorPoolId ==. val poolId)
+            pure $ poolMetadataFetchError
+  pure $ fmap entityVal res
 
 ------------------------------------------------------------------------------------
 

--- a/src/Cardano/Db/Schema.hs
+++ b/src/Cardano/Db/Schema.hs
@@ -60,7 +60,7 @@ share
   PoolMetadataReference
     poolId              Types.PoolId              sqltype=text
     url                 Types.PoolUrl             sqltype=text
-    hash                Types.PoolMetadataHash    sqltype=base16type
+    hash                Types.PoolMetadataHash    sqltype=text
     UniquePoolMetadataReference  poolId hash
 
   -- The table containing the metadata.
@@ -68,7 +68,7 @@ share
   PoolMetadata
     poolId              Types.PoolId              sqltype=text
     tickerName          Types.TickerName          sqltype=text
-    hash                Types.PoolMetadataHash    sqltype=base16type
+    hash                Types.PoolMetadataHash    sqltype=text
     metadata            Types.PoolMetadataRaw     sqltype=text
     pmrId               PoolMetadataReferenceId Maybe
     UniquePoolMetadata  poolId hash
@@ -79,6 +79,17 @@ share
     poolId              PoolId                    sqltype=text
     UniquePoolId poolId
 
+  -- The pool metadata fetch error. We duplicate the poolId for easy access.
+
+  PoolMetadataFetchError
+    fetchTime           UTCTime                   sqltype=timestamp
+    poolId              Types.PoolId              sqltype=text
+    poolHash            Types.PoolMetadataHash    sqltype=text
+    pmrId               PoolMetadataReferenceId
+    fetchError          Text
+    retryCount          Word                      sqltype=uinteger
+    UniquePoolMetadataFetchError fetchTime poolId
+
   -- We actually need the block table to be able to persist sync data
 
   Block
@@ -87,7 +98,6 @@ share
     slotNo              Word64 Maybe        sqltype=uinteger
     blockNo             Word64 Maybe        sqltype=uinteger
     UniqueBlock         hash
-
 
   -- A table containing metadata about the chain. There will probably only ever be one
   -- row in this table.
@@ -110,7 +120,7 @@ share
   -- For now they are grouped under the specific hash of the pool.
   ReservedTicker
     name                Text                    sqltype=text
-    poolHash            Types.PoolMetadataHash  sqltype=base16type
+    poolHash            Types.PoolMetadataHash  sqltype=text
     UniqueReservedTicker name
 
   -- A table containin a list of administrator users that can be used to access the secure API endpoints.

--- a/src/Cardano/Db/Types.hs
+++ b/src/Cardano/Db/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
@@ -14,26 +15,26 @@ import Database.Persist.Class
 --
 -- It may be rendered as hex or as bech32 using the @pool@ prefix.
 --
-newtype PoolId = PoolId { getPoolId :: ByteString }
+newtype PoolId = PoolId { getPoolId :: Text }
   deriving stock (Eq, Show, Ord, Generic)
   deriving newtype PersistField
 
 instance ToJSON PoolId where
     toJSON (PoolId poolId) =
         object
-            [ "poolId" .= decodeUtf8 poolId
+            [ "poolId" .= poolId
             ]
 
 instance FromJSON PoolId where
     parseJSON = withObject "PoolId" $ \o -> do
         poolId <- o .: "poolId"
-        return $ PoolId $ encodeUtf8 poolId
+        return $ PoolId poolId
 
 -- | The hash of a stake pool's metadata.
 --
 -- It may be rendered as hex.
 --
-newtype PoolMetadataHash = PoolMetadataHash { getPoolMetadataHash :: ByteString }
+newtype PoolMetadataHash = PoolMetadataHash { getPoolMetadataHash :: Text }
   deriving stock (Eq, Show, Ord, Generic)
   deriving newtype PersistField
 

--- a/src/Cardano/SmashDbSync.hs
+++ b/src/Cardano/SmashDbSync.hs
@@ -407,6 +407,7 @@ dbSyncProtocols trce env plugin _version codecs _connectionId =
         (metrics, server) <- registerMetricsServer 8080
         race_
             (race_
+                -- TODO(KS): Watch out! We pass the data layer here directly!
                 (runDbThread trce env plugin metrics actionQueue)
                 (runOfflineFetchThread $ modifyName (const "fetch") trce)
             )

--- a/src/FetchQueue.hs
+++ b/src/FetchQueue.hs
@@ -2,6 +2,7 @@ module FetchQueue
   ( FetchQueue -- opaque
   , PoolFetchRetry (..)
   , Retry -- opaque
+  , retryCount
   , emptyFetchQueue
   , lenFetchQueue
   , nullFetchQueue

--- a/test/SmashSpecSM.hs
+++ b/test/SmashSpecSM.hs
@@ -194,10 +194,10 @@ doNotUse :: a
 doNotUse = panic "Should not be used!"
 
 genPoolId :: Gen PoolId
-genPoolId = PoolId . encodeUtf8 <$> genSafeText
+genPoolId = PoolId <$> genSafeText
 
 genPoolHash :: Gen PoolMetadataHash
-genPoolHash = PoolMetadataHash . encodeUtf8 <$> genSafeText
+genPoolHash = PoolMetadataHash <$> genSafeText
 
 -- |Improve this.
 genPoolOfflineMetadataText :: Gen Text


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-1744

There are two ways to query errors:
```
http://localhost:3100/api/v1/errors
```
And if you have the pool id:
```
http://localhost:3100/api/v1/errors?poolId=c0b0e43213a8c898e373928fbfc3df81ee77c0df7dadc3ad6e5bae17
```


Also changed the default flag to enable Basic Auth so people don't forget about that.
Also changed the types to `Text` so we can nicely see them in the DB.
