### PR TITLE
[CAD-1824] List of delisted Stake pools.

### DIFF
--- a/src/Cardano/Db/Query.hs
+++ b/src/Cardano/Db/Query.hs
@@ -14,6 +14,7 @@ module Cardano.Db.Query
   , queryLatestBlockNo
   , queryCheckPoints
   , queryDelistedPool
+  , queryAllDelistedPools
   , queryReservedTicker
   , queryAdminUsers
   , queryPoolMetadataFetchError
@@ -139,6 +140,12 @@ queryDelistedPool poolId = do
             where_ (pool ^. DelistedPoolPoolId ==. val poolId)
             pure pool
   pure $ maybe False (\_ -> True) (listToMaybe res)
+
+-- |Return all delisted pools.
+queryAllDelistedPools :: MonadIO m => ReaderT SqlBackend m [DelistedPool]
+queryAllDelistedPools = do
+  res <- selectList [] []
+  pure $ entityVal <$> res
 
 -- | Check if the ticker is in the table.
 queryReservedTicker :: MonadIO m => Text -> ReaderT SqlBackend m (Maybe ReservedTicker)


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-1824

Testing can be done like this.
If there are no delisted pools, the returning list should be empty:
```
curl --verbose --header "Content-Type: application/json" localhost:3100/api/v1/delisted
```
```
[]
```

You need to delist the existing `poolId` (or several if you want to see several):
```
curl --user ksaric:cirask --verbose --header "Content-Type: application/json" --request PATCH --data '{"poolId":"fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38"}' http://localhost:3100/api/v1/delist

curl --user ksaric:cirask --verbose --header "Content-Type: application/json" --request PATCH --data '{"poolId":"cbf68681bbd1758480391706a9717fad6cecd668d3903552364a5d9f"}' http://localhost:3100/api/v1/delist

curl --user ksaric:cirask --verbose --header "Content-Type: application/json" --request PATCH --data '{"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}' http://localhost:3100/api/v1/delist
```
Then the resulting GET should get you all the `poolId` that you delisted:
```
curl --verbose --header "Content-Type: application/json" localhost:3100/api/v1/delisted
```
```
[{"poolId":"fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38"},{"poolId":"cbf68681bbd1758480391706a9717fad6cecd668d3903552364a5d9f"},{"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}]
```