### PR TITLE
[CAD-1926] Retired pools should be ignored.

### DIFF
--- a/doc/getting-started/how-to-install-smash.md
+++ b/doc/getting-started/how-to-install-smash.md
@@ -316,3 +316,11 @@ The returned list consists of objects that contain:
 - cause - what is the cause of the error and why is it failing
 - retryCount - the number of times we retried to fetch the offline metadata
 
+## Pool unregistrations
+
+It is possible that a pool unregisters, in which case all it's metadata will be unavailable. You can check what pools have unregistered by:
+```
+curl --verbose --header "Content-Type: application/json" http://localhost:3100/api/v1/retired
+```
+
+

--- a/schema/migration-2-0004-20201006.sql
+++ b/schema/migration-2-0004-20201006.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 4 THEN
+    CREATe TABLE "retired_pool"("id" SERIAL8  PRIMARY KEY UNIQUE,"pool_id" text NOT NULL);
+    ALTER TABLE "retired_pool" ADD CONSTRAINT "unique_retired_pool_id" UNIQUE("pool_id");
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 4 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/smash.cabal
+++ b/smash.cabal
@@ -22,10 +22,17 @@ Flag disable-basic-auth
   description:         Disable basic authentication scheme for other authentication mechanisms.
   default:             False
 
+Flag testing-mode
+  description:         A flag for allowing operations that promote easy testing.
+  default:             False
+
 library
 
   if flag(disable-basic-auth)
     cpp-options:       -DDISABLE_BASIC_AUTH
+
+  if flag(testing-mode)
+    cpp-options:       -DTESTING_MODE
 
   exposed-modules:
       Lib

--- a/src/Cardano/Db/Insert.hs
+++ b/src/Cardano/Db/Insert.hs
@@ -8,6 +8,7 @@ module Cardano.Db.Insert
   , insertPoolMetadataReference
   , insertReservedTicker
   , insertDelistedPool
+  , insertRetiredPool
   , insertAdminUser
   , insertPoolMetadataFetchError
 
@@ -53,6 +54,9 @@ insertReservedTicker reservedTicker = do
 
 insertDelistedPool :: (MonadIO m) => DelistedPool -> ReaderT SqlBackend m DelistedPoolId
 insertDelistedPool = insertByReturnKey
+
+insertRetiredPool :: (MonadIO m) => RetiredPool -> ReaderT SqlBackend m RetiredPoolId
+insertRetiredPool = insertByReturnKey
 
 insertAdminUser :: (MonadIO m) => AdminUser -> ReaderT SqlBackend m AdminUserId
 insertAdminUser = insertByReturnKey

--- a/src/Cardano/Db/Schema.hs
+++ b/src/Cardano/Db/Schema.hs
@@ -79,6 +79,12 @@ share
     poolId              PoolId                    sqltype=text
     UniquePoolId poolId
 
+  -- The retired pools.
+
+  RetiredPool
+    poolId              Types.PoolId              sqltype=text
+    UniqueRetiredPoolId poolId
+
   -- The pool metadata fetch error. We duplicate the poolId for easy access.
 
   PoolMetadataFetchError

--- a/src/DbSyncPlugin.hs
+++ b/src/DbSyncPlugin.hs
@@ -3,6 +3,8 @@
 
 module DbSyncPlugin
   ( poolMetadataDbSyncNodePlugin
+  -- * For future testing
+  , insertCardanoBlock
   ) where
 
 import           Cardano.Prelude
@@ -11,21 +13,25 @@ import           Cardano.BM.Trace                            (Trace, logError,
                                                               logInfo)
 
 import           Control.Monad.Logger                        (LoggingT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT, runExceptT)
+import           Control.Monad.Trans.Except.Extra            (firstExceptT,
+                                                              newExceptT,
+                                                              runExceptT)
 import           Control.Monad.Trans.Reader                  (ReaderT)
 
 import           DB                                          (DBFail (..),
                                                               DataLayer (..),
                                                               postgresqlDataLayer)
-import           Offline (fetchInsertNewPoolMetadata)
+import           Offline                                     (fetchInsertNewPoolMetadata)
 import           Types                                       (PoolId (..), PoolMetadataHash (..),
                                                               PoolUrl (..))
 
-import qualified Cardano.Chain.Block as Byron
+import qualified Cardano.Chain.Block                         as Byron
 
 import qualified Data.ByteString.Base16                      as B16
 
-import           Database.Persist.Sql (IsolationLevel (..), SqlBackend, transactionSaveWithIsolation)
+import           Database.Persist.Sql                        (IsolationLevel (..),
+                                                              SqlBackend,
+                                                              transactionSaveWithIsolation)
 
 import qualified Cardano.Db.Insert                           as DB
 import qualified Cardano.Db.Query                            as DB
@@ -37,48 +43,57 @@ import           Cardano.DbSync.Types                        as DbSync
 import           Cardano.DbSync                              (DbSyncNodePlugin (..))
 
 import qualified Cardano.DbSync.Era.Shelley.Util             as Shelley
+import qualified Cardano.DbSync.Era.Byron.Util               as Byron
 
-import           Shelley.Spec.Ledger.BaseTypes (strictMaybeToMaybe)
-import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
-import qualified Shelley.Spec.Ledger.TxData as Shelley
+import           Shelley.Spec.Ledger.BaseTypes               (strictMaybeToMaybe)
+import qualified Shelley.Spec.Ledger.BaseTypes               as Shelley
+import qualified Shelley.Spec.Ledger.TxData                  as Shelley
 
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
-import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
+import           Ouroboros.Consensus.Byron.Ledger            (ByronBlock (..))
+import           Ouroboros.Consensus.Shelley.Ledger.Block    (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosStandardCrypto)
 
+-- |Pass in the @DataLayer@.
 poolMetadataDbSyncNodePlugin :: DbSyncNodePlugin
 poolMetadataDbSyncNodePlugin =
   DbSyncNodePlugin
     { plugOnStartup = []
-    , plugInsertBlock = [insertCardanoBlock]
+    , plugInsertBlock = [insertCardanoBlock postgresqlDataLayer]
     , plugRollbackBlock = []
     }
 
 insertCardanoBlock
-    :: Trace IO Text
+    :: DataLayer
+    -> Trace IO Text
     -> DbSyncEnv
     -> DbSync.BlockDetails
     -> ReaderT SqlBackend (LoggingT IO) (Either DbSyncNodeError ())
-insertCardanoBlock tracer _env block = do
+insertCardanoBlock dataLayer tracer _env block = do
   case block of
-    ByronBlockDetails blk _details -> Right <$> insertByronBlock tracer blk
-    ShelleyBlockDetails blk _details -> insertShelleyBlock tracer blk
+    ByronBlockDetails blk details -> Right <$> insertByronBlock tracer blk details
+    ShelleyBlockDetails blk _details -> insertShelleyBlock dataLayer tracer blk
 
 -- We don't care about Byron, no pools there
 insertByronBlock
-    :: Trace IO Text -> ByronBlock
+    :: Trace IO Text -> ByronBlock -> DbSync.SlotDetails
     -> ReaderT SqlBackend (LoggingT IO) ()
-insertByronBlock tracer blk = do
+insertByronBlock tracer blk _details = do
   case byronBlockRaw blk of
-    Byron.ABOBBlock {} -> pure ()
-    Byron.ABOBBoundary {} -> liftIO $ logInfo tracer "Byron EBB"
+    Byron.ABOBBlock byronBlock -> do
+        let slotNum = Byron.slotNumber byronBlock
+        -- Output in intervals, don't add too much noise to the output.
+        when (slotNum `mod` 5000 == 0) $
+            liftIO . logInfo tracer $ "Byron block, slot: " <> show slotNum
+    Byron.ABOBBoundary {} -> pure ()
+
   transactionSaveWithIsolation Serializable
 
 insertShelleyBlock
-    :: Trace IO Text
+    :: DataLayer
+    -> Trace IO Text
     -> ShelleyBlock TPraosStandardCrypto
     -> ReaderT SqlBackend (LoggingT IO) (Either DbSyncNodeError ())
-insertShelleyBlock tracer blk = do
+insertShelleyBlock dataLayer tracer blk = do
   runExceptT $ do
 
     meta <- firstExceptT (\(e :: DBFail) -> NEError $ show e) . newExceptT $ DB.queryMeta
@@ -93,7 +108,7 @@ insertShelleyBlock tracer blk = do
                     , DB.blockBlockNo = Just $ Shelley.blockNumber blk
                     }
 
-    zipWithM_ (insertTx tracer) [0 .. ] (Shelley.blockTxs blk)
+    zipWithM_ (insertTx dataLayer tracer) [0 .. ] (Shelley.blockTxs blk)
 
     liftIO $ do
       logInfo tracer $ mconcat
@@ -104,21 +119,26 @@ insertShelleyBlock tracer blk = do
 
 insertTx
     :: (MonadIO m)
-    => Trace IO Text -> Word64 -> ShelleyTx
+    => DataLayer
+    -> Trace IO Text
+    -> Word64
+    -> ShelleyTx
     -> ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
-insertTx tracer _blockIndex tx =
-    mapM_ (insertCertificate tracer) (Shelley.txCertificates tx)
+insertTx dataLayer tracer _blockIndex tx =
+    mapM_ (insertCertificate dataLayer tracer) (Shelley.txCertificates tx)
 
 
 insertCertificate
     :: (MonadIO m)
-    => Trace IO Text -> (Word16, ShelleyDCert)
+    => DataLayer
+    -> Trace IO Text
+    -> (Word16, ShelleyDCert)
     -> ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
-insertCertificate tracer (_idx, cert) =
+insertCertificate dataLayer tracer (_idx, cert) =
   case cert of
     Shelley.DCertDeleg _deleg ->
         liftIO $ logInfo tracer "insertCertificate: DCertDeleg"
-    Shelley.DCertPool pool -> insertPoolCert tracer pool
+    Shelley.DCertPool pool -> insertPoolCert dataLayer tracer pool
     Shelley.DCertMir _mir ->
         liftIO $ logInfo tracer "insertCertificate: DCertMir"
     Shelley.DCertGenesis _gen ->
@@ -126,21 +146,36 @@ insertCertificate tracer (_idx, cert) =
 
 insertPoolCert
     :: (MonadIO m)
-    => Trace IO Text -> ShelleyPoolCert
+    => DataLayer
+    -> Trace IO Text
+    -> ShelleyPoolCert
     -> ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
-insertPoolCert tracer pCert =
+insertPoolCert dataLayer tracer pCert =
   case pCert of
-    Shelley.RegPool pParams -> insertPoolRegister tracer pParams
-    Shelley.RetirePool _keyHash _epochNum -> pure ()
-        -- Currently we just maintain the data for the pool, we might not want to
-        -- know whether it's registered
+    Shelley.RegPool pParams -> insertPoolRegister dataLayer tracer pParams
+
+    -- RetirePool (KeyHash 'StakePool era) _ = PoolId
+    Shelley.RetirePool poolPubKey _epochNum -> do
+        let poolIdHash = B16.encode . Shelley.unKeyHashBS $ poolPubKey
+        let poolId = PoolId . decodeUtf8 $ poolIdHash
+
+        liftIO . logInfo tracer $ "Retiring pool with poolId: " <> show poolId
+
+        let addRetiredPool = dlAddRetiredPool dataLayer
+
+        eitherPoolId <- liftIO $ addRetiredPool poolId
+
+        case eitherPoolId of
+            Left err -> liftIO . logError tracer $ "Error adding retiring pool: " <> show err
+            Right poolId' -> liftIO . logInfo tracer $ "Added retiring pool with poolId: " <> show poolId'
 
 insertPoolRegister
     :: forall m. (MonadIO m)
-    => Trace IO Text
+    => DataLayer
+    -> Trace IO Text
     -> ShelleyPoolParams
     -> ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
-insertPoolRegister tracer params = do
+insertPoolRegister dataLayer tracer params = do
   let poolIdHash = B16.encode . Shelley.unKeyHashBS $ Shelley._poolPubKey params
   let poolId = PoolId . decodeUtf8 $ poolIdHash
 
@@ -153,9 +188,11 @@ insertPoolRegister tracer params = do
         let metadataHash = PoolMetadataHash . decodeUtf8 . B16.encode $ Shelley._poolMDHash md
 
         -- Ah. We can see there is garbage all over the code. Needs refactoring.
-        refId <- lift . liftIO $ (dlAddMetaDataReference postgresqlDataLayer) poolId metadataUrl metadataHash
+        -- TODO(KS): Move this above!
+        let addMetaDataReference = dlAddMetaDataReference dataLayer
+        refId <- lift . liftIO $ addMetaDataReference poolId metadataUrl metadataHash
 
-        liftIO $ fetchInsertNewPoolMetadata postgresqlDataLayer tracer refId poolId md
+        liftIO $ fetchInsertNewPoolMetadata dataLayer tracer refId poolId md
 
         liftIO . logInfo tracer $ "Metadata inserted."
 


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-1926

Tested on `qa-shelley`.
Testing instructions. You first need to enable `TESTING_MODE`. When you do that you can check the existing metadata:
```
curl --verbose --header "Content-Type: application/json" http://localhost:3100/api/v1/metadata/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38/93cf2f2fead6c419ccaae1a41f0786de4b9daefea7074d7bda3d288e76e20a97
```
Check the retired pools:
```
curl --verbose --header "Content-Type: application/json" http://localhost:3100/api/v1/retired
```

Then add a retired pool (simulate what the chain will do, this is why we need `TESTING_MODE`):
```
curl --verbose --header "Content-Type: application/json" --request PATCH --data '{"poolId":"fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38"}' http://localhost:3100/api/v1/retired
```

Now notice it's available in the list:
```
curl --verbose --header "Content-Type: application/json" http://localhost:3100/api/v1/retired
```

And you can no longer fetch the metadata:
```
curl --verbose --header "Content-Type: application/json" http://localhost:3100/api/v1/metadata/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38/93cf2f2fead6c419ccaae1a41f0786de4b9daefea7074d7bda3d288e76e20a97
```