### PR TITLE
[CAD-2061] Logs improvement, add information to why an error occured.

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -288,15 +288,15 @@ instance (ToJSON err, ToJSON a) => ToJSON (ApiResult err a) where
 
 -- |Fetch error for the HTTP client fetching the pool.
 data FetchError
-  = FEHashMismatch !Text !Text
-  | FEDataTooLong
-  | FEUrlParseFail !Text
-  | FEJsonDecodeFail !Text
-  | FEHttpException !Text
-  | FEHttpResponse !Int
+  = FEHashMismatch !PoolId !Text !Text !Text
+  | FEDataTooLong !PoolId !Text
+  | FEUrlParseFail !PoolId !Text !Text
+  | FEJsonDecodeFail !PoolId !Text !Text
+  | FEHttpException !PoolId !Text !Text
+  | FEHttpResponse !PoolId !Text !Int
   | FEIOException !Text
-  | FETimeout !Text
-  | FEConnectionFailure
+  | FETimeout !PoolId !Text !Text
+  | FEConnectionFailure !PoolId !Text
 
 -- |Fetch error for the specific @PoolId@ and the @PoolMetadataHash@.
 data PoolFetchError = PoolFetchError !Time.POSIXTime !PoolId !PoolMetadataHash !Text !Word


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2061

The example of the new errors can be seen in the logs and in the database:
```
[smash-node.fetch:Warning:49] [2020-10-16 10:49:04.24 UTC] Hash mismatch from poolId '351d8435256ab7f560255342dd464f7becf8e3bc4f976e0d80a90ef9' when fetching metadata from 'http://adajapan.com/poolMetadata.json'. Expected 0aaea3edecb189fc0b033eec805aff362764e3273997a67ef089f3800bcd9af7 but got 407248607ad13e678b3f7f41509c38d9877287dc0a6f4b4a4127d5d443aae37d.
```

```
[smash-node.fetch:Warning:49] [2020-10-16 10:54:43.50 UTC] Offline pool data from poolId '48cdc5d38323c6ac7d0160dedcbbf0661518a57e4699e618fb86424a' when fetching metadata from 'http://poolpros.tech/poolpros.json' exceeded 512 bytes.
```