### PR TITLE
Release 1.2.0.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Changelog for smash
 
+## 1.2.0
+
+### Story
+
+- [CAD-1358] - Return the caching headers for the HTTP server to work with that
+- [CAD-1823] - Stake pools with issues list
+- [CAD-1824] - List of delisted Stake pools
+- [CAD-1838] - Add whitelisting (listing) to return delisted
+- [CAD-1926] - Retired pools should be ignored
+- [CAD-2061] - Logs improvement, add information to why an error occured
+- [CAD-2074] - Health check endpoint
+- [CAD-2085] - Create migration scripts for SMASH
+- [CAD-2088] - Resolve paths relative to the config file, not the executable
+- [CAD-2093] - Use qualified module names
 
 ## 1.1.0
 

--- a/smash.cabal
+++ b/smash.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               smash
-version:            1.1.0
+version:            1.2.0
 description:
   Please see the README on GitHub at <https://github.com/input-output-hk/smash#readme>
 


### PR DESCRIPTION
The PRs that include clear testing information:
- https://github.com/input-output-hk/smash/pull/90
- https://github.com/input-output-hk/smash/pull/83
- https://github.com/input-output-hk/smash/pull/87
- https://github.com/input-output-hk/smash/pull/89
- https://github.com/input-output-hk/smash/pull/94
- https://github.com/input-output-hk/smash/pull/101

The PRs that are somewhat more complicated to explain how to test:
- https://github.com/input-output-hk/smash/pull/100 - this PR simply changes the genesis files location to be relative to the configuration file
- https://github.com/input-output-hk/smash/pull/80 - this should return the caching header "Cache: Always" when fetching the metadata endpoint