### PR TITLE
nix: add scripts and fix config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist-newstyle/
 tags
 stack.yaml.lock
 result*
+pgpass*

--- a/nix/nixos/default.nix
+++ b/nix/nixos/default.nix
@@ -1,5 +1,4 @@
+
 {
-  imports = [
-    ./smash-service.nix
-  ];
+  imports = import ./module-list.nix;
 }

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,0 +1,3 @@
+[
+  ./smash-service.nix
+]

--- a/nix/nixos/smash-service.nix
+++ b/nix/nixos/smash-service.nix
@@ -2,10 +2,19 @@
 
 let
   cfg = config.services.smash;
-  configFile = __toFile "config.json" (__toJSON (cfg.explorerConfig // cfg.logConfig));
+  self = config.internal.smashPackages;
+  smashConfig = cfg.explorerConfig // {
+    inherit (cfg.nodeConfig) ByronGenesisFile ShelleyGenesisFile ByronGenesisHash ShelleyGenesisHash Protocol RequiresNetworkMagic;
+  };
+  configFile = __toFile "config.json" (__toJSON (smashConfig // cfg.logConfig));
 in {
 
   options = {
+    internal = lib.mkOption {
+      type = lib.types.attrs;
+      internal = true;
+      default = { smashPackages = import ../. {}; };
+    };
     services.smash = {
       enable = lib.mkEnableOption "enable the smash server";
       script = lib.mkOption {
@@ -20,20 +29,25 @@ in {
         type = lib.types.attrs;
         default = cfg.environment.explorerConfig;
       };
-      environment = lib.mkOption {
+      nodeConfig = lib.mkOption {
         type = lib.types.attrs;
-        default = pkgs.iohkNix.cardanoLib.environments.${cfg.environmentName};
+        default = cfg.environment.nodeConfig;
+      };
+      environment = lib.mkOption {
+        type = lib.types.nullOr lib.types.attrs;
+        default = self.iohkNix.cardanoLib.environments.${cfg.environmentName};
       };
       logConfig = lib.mkOption {
         type = lib.types.attrs;
-        default = pkgs.iohkNix.cardanoLib.defaultExplorerLogConfig;
+        default = self.iohkNix.cardanoLib.defaultExplorerLogConfig;
       };
       environmentName = lib.mkOption {
         type = lib.types.str;
         description = "environment name";
       };
       socketPath = lib.mkOption {
-        type = lib.types.path;
+        type = lib.types.nullOr lib.types.path;
+        default = null;
       };
       user = lib.mkOption {
         type = lib.types.str;
@@ -41,10 +55,17 @@ in {
         description = "the user to run as";
       };
       postgres = {
+        generatePGPASS = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "generate pgpass";
+        };
+
         pgpass = lib.mkOption {
           type = lib.types.path;
           default = builtins.toFile "pgpass" "${cfg.postgres.socketdir}:${toString cfg.postgres.port}:${cfg.postgres.database}:${cfg.postgres.user}:*";
         };
+
         socketdir = lib.mkOption {
           type = lib.types.str;
           default = "/run/postgresql";
@@ -52,7 +73,7 @@ in {
         };
         port = lib.mkOption {
           type = lib.types.int;
-          default = config.services.postgresql.port;
+          default = 5432;
           description = "the postgresql port";
         };
         database = lib.mkOption {
@@ -69,22 +90,32 @@ in {
     };
   };
   config = lib.mkIf cfg.enable {
-    services.smash.script = pkgs.writeShellScript "smash" ''
+    services.smash.script = let
+    in pkgs.writeShellScript "smash" ''
       set -euo pipefail
 
-      cp ${cfg.postgres.pgpass} $RUNTIME_DIRECTORY/pgpass
+      RUNTIME_DIRECTORY=''${RUNTIME_DIRECTORY:-$(pwd)}
+      ${if (cfg.socketPath == null) then ''if [ -z ''${CARDANO_NODE_SOCKET_PATH:-} ]
+      then
+        echo "You must set \$CARDANO_NODE_SOCKET_PATH"
+        exit 1
+      fi'' else "export CARDANO_NODE_SOCKET_PATH=\"${cfg.socketPath}\""}
+
+      ${lib.optionalString cfg.postgres.generatePGPASS ''
+      cp ${cfg.postgres.pgpass} /$RUNTIME_DIRECTORY/pgpass
       chmod 0600 $RUNTIME_DIRECTORY/pgpass
-      export SMASHPGPASSFILE=$RUNTIME_DIRECTORY/pgpass
+      export SMASHPGPASSFILE=/$RUNTIME_DIRECTORY/pgpass
+      ''}
 
       ${cfg.package}/bin/smash-exe run-migrations --mdir ${../../schema}
       exec ${cfg.package}/bin/smash-exe run-app-with-db-sync \
         --config ${configFile} \
-        --socket-path ${cfg.socketPath} \
+        --socket-path "$CARDANO_NODE_SOCKET_PATH" \
         --schema-dir ${../../schema}
     '';
     environment.systemPackages = [ cfg.package config.services.postgresql.package ];
     systemd.services.smash = {
-      path = [ cfg.package config.services.postgresql.package pkgs.netcat ];
+      path = [ cfg.package pkgs.netcat pkgs.postgresql ];
       preStart = ''
         for x in {1..10}; do
           nc -z localhost ${toString config.services.smash.postgres.port} && break

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,11 +1,14 @@
 # our packages overlay
-pkgs: _: with pkgs; {
-  smashHaskellPackages = import ./haskell.nix {
-    inherit config
-      lib
-      stdenv
-      haskell-nix
-      buildPackages
-      ;
-  };
+pkgs: _: with pkgs;
+  let
+    compiler = config.haskellNix.compiler or "ghc865";
+  in {
+    smashHaskellPackages = callPackage ./haskell.nix {
+      inherit compiler;
+    };
+
+  # Grab the executable component of our package.
+  inherit (smashHaskellPackages.smash.components.exes)
+      smash-exe;
+
 }

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -1,0 +1,29 @@
+{ pkgs, lib, iohkNix, customConfig }:
+let
+  blacklistedEnvs = [ "selfnode" "shelley_selfnode" "latency-tests" "mainnet-ci" ];
+  environments = lib.filterAttrs (k: v: (!builtins.elem k blacklistedEnvs)) iohkNix.cardanoLib.environments;
+  mkStartScripts = envConfig: let
+    systemdCompat.options = {
+      systemd.services = lib.mkOption {};
+      services.postgresql = lib.mkOption {};
+      users = lib.mkOption {};
+      environment = lib.mkOption {};
+    };
+    eval = let
+      extra = {
+        internal.smashPackages = pkgs;
+        services.smash = {
+          enable = true;
+          environment = envConfig;
+          environmentName = envConfig.name;
+        };
+      };
+    in lib.evalModules {
+      prefix = [];
+      modules = import nixos/module-list.nix ++ [ systemdCompat customConfig extra ];
+      args = { inherit pkgs; };
+    };
+  in {
+    smash = eval.config.services.smash.script;
+  };
+in iohkNix.cardanoLib.forEnvironmentsCustom mkStartScripts environments // { inherit environments; }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f345d26508966e434d8db57d6c3b4ce4202c9fb5",
-        "sha256": "1xcar2r6jm68dp5s8kc2rii0rcg47w41qc1akazbngkj1x6hf1r2",
+        "rev": "f0542228f98a2590e0f39c507b364321995ad802",
+        "sha256": "0yhgjg4bj7cv1lmrb9ig2iapv1mslhn6m750zn2x0n1a3ll267yh",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/f345d26508966e434d8db57d6c3b4ce4202c9fb5.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/f0542228f98a2590e0f39c507b364321995ad802.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
* adds `scripts.<env>.smash` for local testing
* fixes smash config file to have the legacy db-sync config params pulled from nodeConfig
* Defaults RUNTIME_DIRECTORY to $(pwd)

Tested local script as well as deployment on testnet.