### PR TITLE
[CAD-2176] errors endpoint doesn't validate poolId properly.

### DIFF
--- a/smash-servant-types/smash-servant-types.cabal
+++ b/smash-servant-types/smash-servant-types.cabal
@@ -43,6 +43,9 @@ library
     , base                         >=4.7   && <5
     , bytestring
     , cardano-prelude
+    , cardano-api
+    , cardano-db-sync
+    , base16-bytestring
     , persistent
     , servant
     , servant-server


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2176

When we submit an ill-formatted pool id we will get 400 Bad Request since the URL doesn't match.
Example:
```
$> curl --verbose --header "Content-Type: application/json" --request GET http://localhost:3100/api/v1/errors/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38 | jq .
Note: Unnecessary use of -X or --request, GET is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:3100...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3100 (#0)
> GET /api/v1/errors/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38 HTTP/1.1
> Host: localhost:3100
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< Date: Sun, 22 Nov 2020 12:36:09 GMT
< Server: Warp/3.3.5
< Content-Type: application/json;charset=utf-8
< 
{ [1616 bytes data]
100  1603    0  1603    0     0  50093      0 --:--:-- --:--:-- --:--:-- 50093
* Connection #0 to host localhost left intact
[
  {
    "time": "22.11.2020. 12:35:11",
    "retryCount": 0,
    "poolHash": "93cf2f2fead6c419ccaae1a41f0786de4b9daefea7074d7bda3d288e76e20a97",
    "cause": "HTTP Exception from poolId fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38' when fetching metadata from 'https://explorer.shelley-qa.dev.cardano.org/p/3.json' resulted in : InternalException (HandshakeFailed (Error_Protocol (\"certificate rejected: [SelfSigned]\",True,CertificateUnknown)))",
    "poolId": "fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38",
    "utcTime": "1606048511.155603s"
  },
  {
    "time": "22.11.2020. 12:35:29",
    "retryCount": 0,
    "poolHash": "93cf2f2fead6c419ccaae1a41f0786de4b9daefea7074d7bda3d288e76e20a97",
    "cause": "HTTP Exception from poolId fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38' when fetching metadata from 'https://explorer.shelley-qa.dev.cardano.org/p/3.json' resulted in : InternalException (HandshakeFailed (Error_Protocol (\"certificate rejected: [SelfSigned]\",True,CertificateUnknown)))",
    "poolId": "fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38",
    "utcTime": "1606048529.758849s"
  },
  {
    "time": "22.11.2020. 12:36:08",
    "retryCount": 0,
    "poolHash": "93cf2f2fead6c419ccaae1a41f0786de4b9daefea7074d7bda3d288e76e20a97",
    "cause": "HTTP Exception from poolId fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38' when fetching metadata from 'https://explorer.shelley-qa.dev.cardano.org/p/3.json' resulted in : InternalException (HandshakeFailed (Error_Protocol (\"certificate rejected: [SelfSigned]\",True,CertificateUnknown)))",
    "poolId": "fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb38",
    "utcTime": "1606048568.119025s"
  }
]
```
And when we submit an invalid pool id:
```
$> curl --verbose --header "Content-Type: application/json" --request GET http://localhost:3100/api/v1/errors/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb399 | jq .
Note: Unnecessary use of -X or --request, GET is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:3100...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3100 (#0)
> GET /api/v1/errors/fc80a2a814338475c737df5d1c50253046c8c04eb3663336af7beb399 HTTP/1.1
> Host: localhost:3100
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Transfer-Encoding: chunked
< Date: Sun, 22 Nov 2020 12:36:21 GMT
< Server: Warp/3.3.5
< 
{ [5 bytes data]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host localhost left intact
```