### PR TITLE
[CAD-2179] pool_id delist endpoint is returning 200 for any string (not only for valid pool_ids).

### DIFF
--- a/smash-servant-types/smash-servant-types.cabal
+++ b/smash-servant-types/smash-servant-types.cabal
@@ -53,6 +53,7 @@ library
     , swagger2
     , text
     , time
+    , wai
 
   default-language:   Haskell2010
   default-extensions:

--- a/smash-servant-types/src/Cardano/SMASH/API.hs
+++ b/smash-servant-types/src/Cardano/SMASH/API.hs
@@ -1,10 +1,14 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Cardano.SMASH.API
     ( API
@@ -13,23 +17,35 @@ module Cardano.SMASH.API
     ) where
 
 import           Cardano.Prelude
+import           Prelude                       (String, lookup)
 
+import           Data.Aeson                    (FromJSON, eitherDecode')
 import           Data.Swagger                  (Swagger (..))
 
-import           Servant                       ((:<|>) (..), (:>), OctetStream,
-                                                Post)
+import qualified Data.ByteString               as B
+import qualified Data.ByteString.Lazy          as BL
+import           Network.Wai                   (getRequestBodyChunk,
+                                                lazyRequestBody, requestHeaders)
+import           Servant                       ((:<|>) (..), (:>),
+                                                HasServer (..), OctetStream,
+                                                Post, Server)
 import           Servant                       (BasicAuth, Capture, Get, Header,
                                                 Headers, JSON, Patch,
                                                 QueryParam, ReqBody)
+import           Servant.API
+import           Servant.Server
+import           Servant.Server.Internal
+import qualified Servant.Types.SourceT         as S
 
 import           Servant.Swagger               (HasSwagger (..))
 
-import           Cardano.SMASH.DBSync.Db.Error (DBFail)
+import           Cardano.SMASH.DBSync.Db.Error (DBFail (..))
 import           Cardano.SMASH.Types           (ApiResult, HealthStatus,
-                                                PoolFetchError, PoolId,
-                                                PoolMetadataHash,
+                                                PoolFetchError, PoolId (..),
+                                                PoolId, PoolMetadataHash,
                                                 PoolMetadataRaw, TickerName,
                                                 TimeStringFormat, User)
+
 
 -- |For api versioning.
 type APIVersion = "v1"

--- a/smash-servant-types/src/Cardano/SMASH/Types.hs
+++ b/smash-servant-types/src/Cardano/SMASH/Types.hs
@@ -39,33 +39,31 @@ module Cardano.SMASH.Types
 
 import           Cardano.Prelude
 
-import           Control.Monad.Fail              (fail)
+import           Control.Monad.Fail            (fail)
 
-import           Data.Aeson                      (FromJSON (..), ToJSON (..),
-                                                  object, withObject, (.:),
-                                                  (.=))
-import qualified Data.Aeson                      as Aeson
-import           Data.Aeson.Encoding             (unsafeToEncoding)
-import qualified Data.Aeson.Types                as Aeson
-import           Data.Time.Clock                 (UTCTime)
-import qualified Data.Time.Clock.POSIX           as Time
-import           Data.Time.Format                (defaultTimeLocale, formatTime,
-                                                  parseTimeM)
+import           Data.Aeson                    (FromJSON (..), ToJSON (..),
+                                                object, withObject, (.:), (.=))
+import qualified Data.Aeson                    as Aeson
+import           Data.Aeson.Encoding           (unsafeToEncoding)
+import qualified Data.Aeson.Types              as Aeson
+import           Data.Time.Clock               (UTCTime)
+import qualified Data.Time.Clock.POSIX         as Time
+import           Data.Time.Format              (defaultTimeLocale, formatTime,
+                                                parseTimeM)
 
-import           Data.Swagger                    (NamedSchema (..),
-                                                  ToParamSchema (..),
-                                                  ToSchema (..))
-import           Data.Text.Encoding              (encodeUtf8Builder)
+import           Data.Swagger                  (NamedSchema (..),
+                                                ToParamSchema (..),
+                                                ToSchema (..))
+import           Data.Text.Encoding            (encodeUtf8Builder)
 
-import           Servant                         (FromHttpApiData (..),
-                                                  MimeUnrender (..),
-                                                  OctetStream)
+import           Servant                       (FromHttpApiData (..),
+                                                MimeUnrender (..), OctetStream)
 
 import           Cardano.SMASH.DBSync.Db.Error
 import           Cardano.SMASH.DBSync.Db.Types
 
-import qualified Data.ByteString.Lazy            as BL
-import qualified Data.Text.Encoding              as E
+import qualified Data.ByteString.Lazy          as BL
+import qualified Data.Text.Encoding            as E
 
 -- | The basic @Configuration@.
 data Configuration = Configuration

--- a/smash-servant-types/src/Cardano/SMASH/Types.hs
+++ b/smash-servant-types/src/Cardano/SMASH/Types.hs
@@ -47,7 +47,6 @@ import           Data.Aeson                      (FromJSON (..), ToJSON (..),
 import qualified Data.Aeson                      as Aeson
 import           Data.Aeson.Encoding             (unsafeToEncoding)
 import qualified Data.Aeson.Types                as Aeson
-import qualified Data.ByteString.Char8           as BSC
 import           Data.Time.Clock                 (UTCTime)
 import qualified Data.Time.Clock.POSIX           as Time
 import           Data.Time.Format                (defaultTimeLocale, formatTime,
@@ -62,11 +61,9 @@ import           Servant                         (FromHttpApiData (..),
                                                   MimeUnrender (..),
                                                   OctetStream)
 
-import           Cardano.Api.Typed               hiding (PoolId)
 import           Cardano.SMASH.DBSync.Db.Error
 import           Cardano.SMASH.DBSync.Db.Types
 
-import qualified Data.ByteString.Base16          as B16
 import qualified Data.ByteString.Lazy            as BL
 import qualified Data.Text.Encoding              as E
 
@@ -142,27 +139,7 @@ instance FromHttpApiData TickerName where
 -- Currently deserializing from safe types, unwrapping and wrapping it up again.
 -- The underlying DB representation is HEX.
 instance FromHttpApiData PoolId where
-    parseUrlPiece poolId =
-        case pBech32OrHexStakePoolId poolId of
-            Nothing -> Left "Unable to parse pool id. Wrong format."
-            Just poolId' -> Right . PoolId . decodeUtf8 . B16.encode . serialiseToRawBytes $ poolId'
-
-      where
-        -- bech32 pool <<< e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae
-        -- bech32 <<< pool1uh9c4zw2htfvkgh2s4prhja7yu8jj2lrm05r39yy2mf6uqqegn6
-        pBech32OrHexStakePoolId :: Text -> Maybe (Hash StakePoolKey)
-        pBech32OrHexStakePoolId str = pBech32StakePoolId str <|> pHexStakePoolId str
-
-        -- e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae
-        pHexStakePoolId :: Text -> Maybe (Hash StakePoolKey)
-        pHexStakePoolId =
-            deserialiseFromRawBytesHex (AsHash AsStakePoolKey) . BSC.pack . toS
-
-        -- pool1uh9c4zw2htfvkgh2s4prhja7yu8jj2lrm05r39yy2mf6uqqegn6
-        pBech32StakePoolId :: Text -> Maybe (Hash StakePoolKey)
-        pBech32StakePoolId =
-          either (const Nothing) Just
-            . deserialiseFromBech32 (AsHash AsStakePoolKey)
+    parseUrlPiece poolId = parsePoolId poolId
 
 instance ToSchema PoolMetadataHash where
   declareNamedSchema _ =

--- a/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
@@ -56,7 +56,12 @@ insertReservedTicker reservedTicker = do
         Just _key -> return . Left . ReservedTickerAlreadyInserted $ show reservedTicker
 
 insertDelistedPool :: (MonadIO m) => DelistedPool -> ReaderT SqlBackend m (Either DBFail DelistedPoolId)
-insertDelistedPool = insertByReturnKey
+insertDelistedPool delistedPool = do
+    isUnique <- checkUnique delistedPool
+    -- If there is no unique constraint violated, insert, otherwise return error.
+    case isUnique of
+        Nothing -> insertByReturnKey delistedPool
+        Just _key -> return . Left . DbInsertError $ "Delisted pool already exists!"
 
 insertRetiredPool :: (MonadIO m) => RetiredPool -> ReaderT SqlBackend m (Either DBFail RetiredPoolId)
 insertRetiredPool = insertByReturnKey

--- a/stack.yaml
+++ b/stack.yaml
@@ -27,6 +27,10 @@ extra-deps:
   - persistent-postgresql-2.10.1.2
   - persistent-template-2.8.2.3
 
+  # Just checking to see what version we have
+  - servant-0.16.2
+  - servant-server-0.16.2
+
   # This is something extra we need.
   - git: https://github.com/input-output-hk/ouroboros-network
     commit: f0eb6e439e7c0121476ded5e88d2f638e8aa36ac


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2179

Also added validation to the `TickerName`.
Example of how to test.

Let's see what is delisted:
```
$> curl --verbose --header "Content-Type: application/json" --request GET http://localhost:3100/api/v1/delisted
[]
```
And let's delist a couple of them now:
```
$> curl --verbose --user ksaric:cirask --header "Content-Type: application/json" --request PATCH --data '{"poolId":"e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae"}' http://localhost:3100/api/v1/delist

{"poolId":"e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae"}
```
But what happens if I try to do that with a wrong format (added `e` at the end):
```
$> curl --verbose --user ksaric:cirask --header "Content-Type: application/json" --request PATCH --data '{"poolId":"e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3aee"}' http://localhost:3100/api/v1/delist

Error in $: Unable to parse pool id. Wrong format.
```
What about bech32:
```
$> curl --verbose --user ksaric:cirask --header "Content-Type: application/json" --request PATCH --data '{"poolId":"pool1uh9c4zw2htfvkgh2s4prhja7yu8jj2lrm05r39yy2mf6uqqegn6"}' http://localhost:3100/api/v1/delist

{"poolId":"e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae"}
```

The result:
```
$> curl --verbose --header "Content-Type: application/json" --request GET http://localhost:3100/api/v1/delisted
[{"poolId":"e5cb8a89cabad2cb22ea85423bcbbe270f292be3dbe838948456d3ae"}]
```