### PR TITLE
Use own cardano-node revision for integration test

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,7 @@ let
   };
 
   packages = {
-    inherit haskellPackages scripts smash-exe smash-exe-testing;
+    inherit haskellPackages scripts smash-exe smash-exe-testing cardano-node;
     inherit (haskellPackages.smash.identifier) version;
 
     # `tests` are the test suites which have been built.

--- a/nix/nixos/tests/smash-test.nix
+++ b/nix/nixos/tests/smash-test.nix
@@ -23,6 +23,7 @@ with pkgs; with commonLib;
       services.cardano-node = {
         enable = true;
         environment = "shelley_testnet";
+        package = smashHaskellPackages.cardano-node.components.exes.cardano-node;
       };
       services.postgresql = {
         enable = true;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -26,6 +26,9 @@ pkgs: _: with pkgs;
   inherit (smashHaskellPackages.smash.components.exes)
       smash-exe;
 
+  inherit (smashHaskellPackages.cardano-node.components.exes)
+    cardano-node;
+
   smash-exe-testing = smashTestingHaskellPackages.smash.components.exes.smash-exe;
 
 }

--- a/release.nix
+++ b/release.nix
@@ -73,6 +73,7 @@ let
     (collectJobs jobs.native.checks)
     (collectJobs jobs.native.libs)
     (collectJobs jobs.native.exes)
+    [ jobs.native.cardano-node.x86_64-linux ]
   ]));
 
 in jobs


### PR DESCRIPTION
 since it is the revision used for prod deployment.