### PR TITLE
Release 1.3.0.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,21 @@
 # Changelog for smash
 
-## Next version
+## 1.3.0
 
 ### Story
 
 - [CAD-2169] - Expose API types in a separate package
+- [CAD-2177] - smash should work also with pool_ids in Bech32 format
+- [CAD-2182] - Pool insertion and ticker insertion should be added into API
+- [CAD-2183] - Add/remove admin user via CLI
+- [CAD-2323] - Bump up to Allegra Hard Fork
+
+### Bug
+
+- [CAD-2176] - errors endpoint doesn't validate poolId properly
+- [CAD-2178] - The retryCount from the /errors endpoint is not correctly incremented
+- [CAD-2179] - pool_id delist endpoint is returning 200 for any string (not only for valid pool_ids)
+- [CAD-2181] - All queries that don't return anything should return 404
 
 ## 1.2.0
 

--- a/doc/getting-started/how-to-install-smash.md
+++ b/doc/getting-started/how-to-install-smash.md
@@ -128,7 +128,7 @@ cardano-node --genesis-file genesis.json --socket-path node.socket --config conf
 
 You can then run ``smash`` using e.g:
 ```
-SMASHPGPASSFILE=./config/pgpass cabal run smash-exe -- run-app-with-db-sync --config config.yaml --socket-path node.socket --schema-dir schema/
+SMASHPGPASSFILE=./config/pgpass cabal run smash-exe -- run-app-with-db-sync --config config.yaml --socket-path node.socket --schema-dir schema/ --state-dir ledger-state/mainnet
 ```
 You can also run a mainnet node using a Nix command:
 ```

--- a/doc/getting-started/how-to-run-smash.md
+++ b/doc/getting-started/how-to-run-smash.md
@@ -102,7 +102,7 @@ We need to run it using appropriate parameters, since running it requires it to 
 The socket path is just pointing to a socket that will be used for communication with the node.
 The example:
 ```
-SMASHPGPASSFILE=config/pgpass ./smash-local run-app-with-db-sync --config config/testnet-config.yaml --socket-path ../cardano-node/state-node-shelley_testnet/node.socket --schema-dir schema/
+SMASHPGPASSFILE=config/pgpass ./smash-local run-app-with-db-sync --config config/testnet-config.yaml --socket-path ../cardano-node/state-node-shelley_testnet/node.socket --schema-dir schema/ --state-dir ledger-state/shelley-testnet
 ```
 
 After this, the SMASH application should start syncing blocks and picking up pools.

--- a/nix/nixos/smash-service.nix
+++ b/nix/nixos/smash-service.nix
@@ -122,13 +122,14 @@ in {
       exec ${cfg.package}/bin/smash-exe run-app-with-db-sync \
         --config ${configFile} \
         --socket-path "$CARDANO_NODE_SOCKET_PATH" \
-        --schema-dir ${../../schema}
+        --schema-dir ${../../schema} \
+        --state-dir $STATE_DIRECTORY
     '';
     environment.systemPackages = [ cfg.package config.services.postgresql.package ];
     systemd.services.smash = {
       path = [ cfg.package pkgs.netcat pkgs.postgresql ];
       preStart = ''
-        for x in {1..30}; do
+        for x in {1..60}; do
           nc -z localhost ${toString config.services.smash.postgres.port} && break
           echo loop $x: waiting for postgresql 2 sec...
           sleep 2
@@ -139,6 +140,7 @@ in {
         ExecStart = config.services.smash.script;
         DynamicUser = true;
         RuntimeDirectory = "smash";
+        StateDirectory = "smash";
       };
 
       wantedBy = [ "multi-user.target" ];

--- a/smash-servant-types/smash-servant-types.cabal
+++ b/smash-servant-types/smash-servant-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               smash-servant-types
-version:            1.2.0
+version:            1.3.0
 description:
   Shared servant API types for SMASH
 

--- a/smash/smash.cabal
+++ b/smash/smash.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.12
 name:               smash
-version:            1.2.0
+version:            1.3.0
 description:
   Please see the README on GitHub at <https://github.com/input-output-hk/smash#readme>
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.24.1.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/5ed4af4df2a609361260f159cd0e47e1c4073e2c/snapshots/cardano-1.24.2.yaml
 compiler: ghc-8.6.5
 
 #allow-newer: true


### PR DESCRIPTION
Directly depends on https://github.com/input-output-hk/smash/pull/127, the PRs from the changelog contain the info about how to test them.

Also important to note that it depends on `cardano-db-sync` 7.1.

PRs:
- https://github.com/input-output-hk/smash/pull/112
- https://github.com/input-output-hk/smash/pull/122
- https://github.com/input-output-hk/smash/pull/123
- https://github.com/input-output-hk/smash/pull/125
- https://github.com/input-output-hk/smash/pull/124
- https://github.com/input-output-hk/smash/pull/117
- https://github.com/input-output-hk/smash/pull/119
- https://github.com/input-output-hk/smash/pull/121
