### PR TITLE
[CAD-2449] Add API endpoint for checking valid pool id.

### DIFF
--- a/schema/force-resync.sql
+++ b/schema/force-resync.sql
@@ -1,0 +1,7 @@
+-- Clear block information, force re-sync.
+TRUNCATE pool_metadata;
+TRUNCATE pool_metadata_reference CASCADE;
+TRUNCATE pool;
+TRUNCATE retired_pool;
+TRUNCATE pool_metadata_fetch_error CASCADE;
+TRUNCATE block;

--- a/schema/migration-2-0006-20210108.sql
+++ b/schema/migration-2-0006-20210108.sql
@@ -1,0 +1,22 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 6 THEN
+    -- Fix the pool table.
+    DROP TABLE "pool";
+    CREATe TABLE "pool"("id" SERIAL8  PRIMARY KEY UNIQUE,"pool_id" text NOT NULL);
+    ALTER TABLE "pool" ADD CONSTRAINT "unique_pool_id" UNIQUE("pool_id");
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 6 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/smash-servant-types/src/Cardano/SMASH/API.hs
+++ b/smash-servant-types/src/Cardano/SMASH/API.hs
@@ -104,6 +104,7 @@ type EnlistPoolAPI = BasicAuthURL :> "api" :> APIVersion :> "enlist" :> ReqBody 
 
 type RetiredPoolsAPI = "api" :> APIVersion :> "retired" :> ApiRes Get [PoolId]
 
+type CheckPoolAPI = "api" :> APIVersion :> "exists" :> Capture "poolId" PoolId :> ApiRes Get PoolId
 
 -- The full API.
 type SmashAPI =  OfflineMetadataAPI
@@ -113,6 +114,7 @@ type SmashAPI =  OfflineMetadataAPI
             :<|> EnlistPoolAPI
             :<|> FetchPoolErrorAPI
             :<|> RetiredPoolsAPI
+            :<|> CheckPoolAPI
 #ifdef TESTING_MODE
             :<|> RetirePoolAPI
             :<|> AddPoolAPI

--- a/smash/smash.cabal
+++ b/smash/smash.cabal
@@ -133,6 +133,7 @@ executable smash-exe
     , esqueleto
     , transformers
     , prometheus
+    , filepath
 
   default-language:   Haskell2010
   default-extensions:

--- a/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
@@ -4,6 +4,7 @@
 module Cardano.SMASH.DBSync.Db.Insert
   ( insertBlock
   , insertMeta
+  , insertPool
   , insertPoolMetadata
   , insertPoolMetadataReference
   , insertReservedTicker
@@ -37,6 +38,9 @@ insertBlock = insertByReturnKey
 
 insertMeta :: (MonadIO m) => Meta -> ReaderT SqlBackend m (Either DBFail MetaId)
 insertMeta meta = insertByReturnKey meta
+
+insertPool :: (MonadIO m) => Pool -> ReaderT SqlBackend m (Either DBFail PoolId)
+insertPool pool = insertByReturnKey pool
 
 insertPoolMetadata :: (MonadIO m) => PoolMetadata -> ReaderT SqlBackend m (Either DBFail PoolMetadataId)
 insertPoolMetadata = insertByReturnKey

--- a/smash/src/Cardano/SMASH/DBSync/Db/Schema.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Schema.hs
@@ -78,7 +78,7 @@ share
   -- The pools themselves (identified by the owner vkey hash)
 
   Pool
-    poolId              PoolId                    sqltype=text
+    poolId              Types.PoolId              sqltype=text
     UniquePoolId poolId
 
   -- The retired pools.
@@ -88,6 +88,7 @@ share
     UniqueRetiredPoolId poolId
 
   -- The pool metadata fetch error. We duplicate the poolId for easy access.
+  -- TODO(KS): Debatable whether we need to persist this between migrations!
 
   PoolMetadataFetchError
     fetchTime           UTCTime                   sqltype=timestamp
@@ -107,8 +108,13 @@ share
     blockNo             Word64 Maybe        sqltype=uinteger
     UniqueBlock         hash
 
+  --------------------------------------------------------------------------
+  -- Tables below should be preserved when migration occurs!
+  --------------------------------------------------------------------------
+
   -- A table containing metadata about the chain. There will probably only ever be one
   -- row in this table.
+  -- TODO(KS): This can be left alone when migration occurs since it should be the same!
   Meta
     protocolConst       Word64              -- The block security parameter.
     slotDuration        Word64              -- Slot duration in milliseconds.

--- a/smash/src/Cardano/SMASH/Offline.hs
+++ b/smash/src/Cardano/SMASH/Offline.hs
@@ -190,7 +190,8 @@ fetchInsertDefault poolId tracer pfr = do
       then left $ FEHashMismatch poolId expectedHash (renderByteStringHex hashFromMetadata) poolMetadataURL
       else liftIO . logInfo tracer $ "Inserting pool data with hash: " <> expectedHash
 
-    let addPoolMetadata = dlAddPoolMetadata postgresqlDataLayer
+    let dataLayer = postgresqlDataLayer (Just tracer)
+    let addPoolMetadata = dlAddPoolMetadata dataLayer
 
     _ <- liftIO $
             addPoolMetadata
@@ -206,7 +207,8 @@ fetchInsertDefault poolId tracer pfr = do
 runOfflineFetchThread :: Trace IO Text -> IO ()
 runOfflineFetchThread trce = do
     liftIO $ logInfo trce "Runing Offline fetch thread"
-    fetchLoop postgresqlDataLayer FetchLoopForever trce queryPoolFetchRetryDefault
+    let dataLayer = postgresqlDataLayer (Just trce)
+    fetchLoop dataLayer FetchLoopForever trce queryPoolFetchRetryDefault
 
 ---------------------------------------------------------------------------------------------------
 

--- a/smash/test/MigrationSpec.hs
+++ b/smash/test/MigrationSpec.hs
@@ -68,7 +68,7 @@ migrationSpec = do
                             , pfrRetry       = retry'
                             }
 
-                let dataLayer = postgresqlDataLayer
+                let dataLayer = postgresqlDataLayer Nothing
 
                 let fetchInsert = \_ _ _ -> left $ FEIOException "Dunno"
 
@@ -97,7 +97,7 @@ migrationTest = do
 
     -- TODO(KS): This version HAS to be changed manually so we don't mess up the
     -- migration.
-    let expected = SchemaVersion 1 5 0
+    let expected = SchemaVersion 1 6 0
     actual <- getDbSchemaVersion
     unless (expected == actual) $
         panic $ mconcat


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2449

This works correctly but **requires the full resync from the blockchain** since we need to add pool ids from the beginning of the blockchain.
This can be achieved using the added command which removes all blockchain-related state and forces a resync:
```
SMASHPGPASSFILE=config/pgpass stack run smash-exe -- force-resync --mdir ./schema --config config/shelley-qa-config.yaml
```

Example of how it works.
The existing pool id:
```
curl -X GET http://localhost:3100/api/v1/exists/8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66 
{"poolId":"8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa66"}
```

Non-existing pool id:
```
curl -X GET http://localhost:3100/api/v1/exists/8517fa7042cb9494818861c53c87780b4975c0bd402e3ed85168aa65
{"code":"RecordDoesNotExist","description":"The requested record does not exist."}
```
