### PR TITLE
[CAD-2060] SMASH cache, update SMASH with new db-sync version deps.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
-index-state: 2021-01-08T00:00:00Z
+index-state: 2021-02-20T00:00:00Z
+
+with-compiler: ghc-8.10.4
 
 packages:
     ./smash
@@ -17,7 +19,13 @@ package smash
 
 ------------------------------------------------------------------------------
 
+-- Disable all tests by default
+
 tests: False
+
+test-show-details: direct
+
+-- Then enable specific tests in this repo
 
 package smash
   tests: True
@@ -35,15 +43,13 @@ package cardano-node
 package ouroboros-consensus-cardano
   tests: False
 
-test-show-details: direct
-
 ------------------------------------------------------------------------------
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: d5aa846e0751227aa6461084d6ea0567535f752e
-  --sha256: 0xhm53yycjp6zgqzx6l3hvmgl3046g276qq7vx2wbhljwwqvvk15
+  tag: e8359d608c47709a22a140d9f34c2ede43a67922
+  --sha256: 064x1m1kpfj1q72mgzpfgahx7gj2c3sy0r6y9nszv74pnkmkid8x
   subdir:
     cardano-sync
     cardano-db
@@ -70,8 +76,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 097890495cbb0e8b62106bcd090a5721c3f4b36f
-  --sha256: 0i3y9n0rsyarvhfqzzzjccqnjgwb9fbmbs6b7vj40afjhimf5hcj
+  tag: 99e2f2e32ebfca3291fa523ddcae14c8cbb48fa0
+  --sha256: 0fy8y7cp10ls8p3zs2fqzqpd41vri6z0imhyif5wa9bi2rp57i3z
   subdir:
     byron/crypto
     byron/crypto/test
@@ -89,8 +95,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f
-  --sha256: 1scffi7igv4kj93bpjf8yibcaq0sskfikmm00f7r6q031l53y50c
+  tag: e15515b785f7caae0ae5d997b26d9c4518062c71
+  --sha256: 14w39l4jgxhb68xzv889bibj8q44aknqnsdrz1kbwx2ca3yzbkpw
   subdir:
     cardano-api
     cardano-config
@@ -115,8 +121,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 563e79f28c6da5c547463391d4c58a81442e48db
-  --sha256: 1is18h9kk8j16my89q76nihvapiiff3jl8777vk7c4wl2h4zry2w
+  tag: 60b13d80afa266f02f363672950e896ed735e807
+  --sha256: 0gci6r4c6ldrgracbr4fni4hbrl62lmm5p70cafkwk21a0kqs8cz
   subdir:
     contra-tracer
     iohk-monitoring
@@ -130,8 +136,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 6cb9052bde39472a0555d19ade8a42da63d3e904
-  --sha256: 0rz4acz15wda6yfc7nls6g94gcwg2an5zibv0irkxk297n76gkmg
+  tag: 96cf17bcc6ea4ef455a19430313ce17d476d62b5
+  --sha256: 00xp605lb8qp1jhp43mg7818x8yzn2rnsd18qcy5721yj4q675nz
   subdir:
     cardano-client
     io-sim

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "42b10678ff45cd1bd668093c3a9bcb093d5c1760",
-        "sha256": "0bianzf3y17qikx3cbzcr587hnljg3fgnax7y93nn4s9q2b8w283",
+        "rev": "eb8a7647fd88c506424b6d131963330e43bff7c9",
+        "sha256": "1nmmca2dcy23f39hyka534v08bd8bs0nan4lg7p6phx9i2mq0wjh",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/42b10678ff45cd1bd668093c3a9bcb093d5c1760.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/eb8a7647fd88c506424b6d131963330e43bff7c9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "4efc38924c64c23a582c84950c8c25f72ff049cc",
-        "sha256": "0nhwyrd0xc72yj5q3jqa2wl4khp4g7n72i45cxy2rgn9nrp8wqh0",
+        "rev": "666e57027dca46964c6a26efcc2042b247d354a5",
+        "sha256": "0v5sgs8wf47x4csr6f70z2hi47my5r981m71nqgkj04n0sr6lz4b",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/4efc38924c64c23a582c84950c8c25f72ff049cc.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/666e57027dca46964c6a26efcc2042b247d354a5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/smash-servant-types/src/Cardano/SMASH/DBSync/Db/Types.hs
+++ b/smash-servant-types/src/Cardano/SMASH/DBSync/Db/Types.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE DerivingVia                #-}
 
 module Cardano.SMASH.DBSync.Db.Types where
 
@@ -14,7 +14,11 @@ import           Data.Aeson             (FromJSON (..), ToJSON (..), object,
                                          withObject, (.:), (.=))
 import           Database.Persist.Class
 
-import           Cardano.Api.Typed      hiding (PoolId)
+import           Cardano.Api            (AsType (..), Hash,
+                                         deserialiseFromBech32,
+                                         deserialiseFromRawBytesHex,
+                                         serialiseToRawBytes)
+import           Cardano.Api.Shelley    (StakePoolKey)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8  as BSC
 
@@ -129,7 +133,7 @@ instance FromJSON TickerName where
 
 -- |Util.
 eitherToMonadFail :: MonadFail m => Either Text a -> m a
-eitherToMonadFail (Left err) = fail $ toS err
+eitherToMonadFail (Left err)  = fail $ toS err
 eitherToMonadFail (Right val) = return val
 
 -- |The validation for the ticker name we can reuse.

--- a/smash/smash.cabal
+++ b/smash/smash.cabal
@@ -82,6 +82,7 @@ library
     , monad-logger
     , ouroboros-consensus-byron
     , ouroboros-consensus-cardano
+    , ouroboros-network
     , persistent
     , persistent-postgresql
     , persistent-template          >=2.7.0
@@ -147,6 +148,7 @@ executable smash-exe
     , persistent
     , ouroboros-consensus-cardano
     , ouroboros-consensus-shelley
+    , ouroboros-network
     , shelley-spec-ledger
 
   default-language:   Haskell2010

--- a/smash/src/Cardano/SMASH/DB.hs
+++ b/smash/src/Cardano/SMASH/DB.hs
@@ -44,8 +44,6 @@ import           Cardano.SMASH.DBSync.Db.Insert            (insertAdminUser,
                                                             insertPoolMetadataReference,
                                                             insertReservedTicker,
                                                             insertRetiredPool)
-import           Cardano.SMASH.DBSync.Db.Query             (DBFail (..),
-                                                            queryPoolMetadata)
 import           Cardano.SMASH.Types
 
 import           Cardano.SMASH.DBSync.Db.Error             as X
@@ -70,7 +68,6 @@ import           Cardano.SMASH.DBSync.Db.Schema            as X (AdminUser (..),
                                                                  ReservedTickerId,
                                                                  RetiredPool (..),
                                                                  poolMetadataMetadata)
-import           Cardano.SMASH.DBSync.Db.Types             (TickerName (..))
 
 -- | This is the data layer for the DB.
 -- The resulting operation has to be @IO@, it can be made more granular,

--- a/smash/src/Cardano/SMASH/DBSync/Db/Delete.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Delete.hs
@@ -9,9 +9,6 @@ module Cardano.SMASH.DBSync.Db.Delete
 
 import           Cardano.Prelude                hiding (Meta)
 
-import           Control.Monad.IO.Class         (MonadIO)
-import           Control.Monad.Trans.Reader     (ReaderT)
-
 import           Database.Persist.Sql           (SqlBackend, deleteCascade,
                                                  selectKeysList, (==.))
 

--- a/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Insert.hs
@@ -19,10 +19,9 @@ module Cardano.SMASH.DBSync.Db.Insert
 
 import           Cardano.Prelude                hiding (Meta, replace)
 
-import           Control.Monad.IO.Class         (MonadIO)
-import           Control.Monad.Trans.Reader     (ReaderT, mapReaderT)
+import           Control.Monad.Trans.Reader     (mapReaderT)
 
-import           Database.Persist.Class         (AtLeastOneUniqueKey, Key,
+import           Database.Persist.Class         (AtLeastOneUniqueKey,
                                                  PersistEntityBackend,
                                                  checkUnique, getByValue,
                                                  insert)

--- a/smash/src/Cardano/SMASH/DBSync/Db/Migration.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Migration.hs
@@ -11,22 +11,16 @@ module Cardano.SMASH.DBSync.Db.Migration
 
 import           Cardano.Prelude
 
-import           Control.Exception                         (SomeException,
-                                                            bracket, handle)
-import           Control.Monad                             (forM_)
-import           Control.Monad.IO.Class                    (liftIO)
 import           Control.Monad.Logger                      (NoLoggingT)
-import           Control.Monad.Trans.Reader                (ReaderT)
 import           Control.Monad.Trans.Resource              (runResourceT)
 
 import           Cardano.BM.Trace                          (Trace, logInfo)
 
 import qualified Data.ByteString.Char8                     as BS
 import           Data.Conduit.Binary                       (sinkHandle)
-import           Data.Conduit.Process                      (sourceCmdWithConsumer, system)
-import           Data.Either                               (partitionEithers)
+import           Data.Conduit.Process                      (sourceCmdWithConsumer,
+                                                            system)
 import qualified Data.List                                 as List
-import           Data.Text                                 (Text)
 import qualified Data.Text                                 as Text
 import qualified Data.Text.IO                              as Text
 import           Data.Time.Clock                           (getCurrentTime)
@@ -47,14 +41,9 @@ import           Cardano.SMASH.DBSync.Db.Run
 import           Cardano.SMASH.DBSync.Db.Schema
 
 import           System.Directory                          (listDirectory)
-import           System.Exit                               (ExitCode (..),
-                                                            exitFailure)
 import           System.FilePath                           (takeFileName, (</>))
-import           System.IO                                 (Handle,
-                                                            IOMode (AppendMode),
-                                                            hClose, hFlush,
-                                                            hPrint, openFile,
-                                                            stdout)
+import           System.IO                                 (hClose, hFlush,
+                                                            hPrint)
 
 
 

--- a/smash/src/Cardano/SMASH/DBSync/Db/Migration/Haskell.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Migration/Haskell.hs
@@ -7,11 +7,8 @@ module Cardano.SMASH.DBSync.Db.Migration.Haskell
 
 import           Cardano.Prelude
 
-import           Control.Exception (SomeException, handle)
 import           Control.Monad.Logger (MonadLogger)
-import           Control.Monad.Trans.Reader (ReaderT)
 
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
 import           Database.Persist.Sql (SqlBackend)
@@ -19,8 +16,7 @@ import           Database.Persist.Sql (SqlBackend)
 import           Cardano.SMASH.DBSync.Db.Migration.Version
 import           Cardano.SMASH.DBSync.Db.Run
 
-import           System.Exit (exitFailure)
-import           System.IO (Handle, hClose, hFlush, stdout)
+import           System.IO (hClose, hFlush)
 
 -- | Run a migration written in Haskell (eg one that cannot easily be done in SQL).
 -- The Haskell migration is paired with an SQL migration and uses the same MigrationVersion

--- a/smash/src/Cardano/SMASH/DBSync/Db/PGConfig.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/PGConfig.hs
@@ -12,10 +12,8 @@ module Cardano.SMASH.DBSync.Db.PGConfig
 
 import           Cardano.Prelude
 
-import           Control.Exception (IOException)
 import qualified Control.Exception as Exception
 
-import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
 
 import           Database.Persist.Postgresql (ConnectionString)

--- a/smash/src/Cardano/SMASH/DBSync/Db/Query.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Query.hs
@@ -33,14 +33,9 @@ module Cardano.SMASH.DBSync.Db.Query
 import           Cardano.Prelude                hiding (Meta, from, isJust,
                                                  isNothing, maybeToEither)
 
-import           Control.Monad                  (join)
 import           Control.Monad.Extra            (mapMaybeM)
-import           Control.Monad.Trans.Reader     (ReaderT)
 
-import           Data.ByteString.Char8          (ByteString)
-import           Data.Maybe                     (catMaybes, listToMaybe)
 import           Data.Time.Clock                (UTCTime)
-import           Data.Word                      (Word64)
 
 import           Database.Esqueleto             (Entity, PersistField, SqlExpr,
                                                  Value, ValueList, countRows,

--- a/smash/src/Cardano/SMASH/DBSync/Db/Run.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Run.hs
@@ -23,17 +23,14 @@ import           Control.Tracer                       (traceWith)
 
 import           Cardano.Prelude
 
-import           Control.Monad.IO.Class               (liftIO)
 import           Control.Monad.Logger                 (LogLevel (..), LogSource,
                                                        LoggingT, NoLoggingT,
                                                        defaultLogStr,
                                                        runLoggingT,
                                                        runNoLoggingT,
                                                        runStdoutLoggingT)
-import           Control.Monad.Trans.Reader           (ReaderT)
 
 import qualified Data.ByteString.Char8                as BS
-import           Data.Text                            (Text)
 import qualified Data.Text.Encoding                   as T
 import qualified Data.Text.Lazy.Builder               as LT
 import qualified Data.Text.Lazy.IO                    as LT
@@ -41,7 +38,6 @@ import qualified Data.Text.Lazy.IO                    as LT
 import           Database.Persist.Postgresql          (openSimpleConn,
                                                        withPostgresqlConn)
 import           Database.Persist.Sql                 (IsolationLevel (..),
-                                                       SqlBackend,
                                                        runSqlConnWithIsolation)
 import           Database.PostgreSQL.Simple           (connectPostgreSQL)
 
@@ -54,7 +50,6 @@ import           Cardano.SMASH.DBSync.Db.PGConfig
 
 import           Language.Haskell.TH.Syntax           (Loc)
 
-import           System.IO                            (Handle, stdout)
 import           System.Log.FastLogger                (LogStr, fromLogStr)
 
 -- | Run a DB action logging via the provided Handle.

--- a/smash/src/Cardano/SMASH/DBSync/Db/Schema.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Db/Schema.hs
@@ -19,10 +19,7 @@ module Cardano.SMASH.DBSync.Db.Schema where
 
 import           Cardano.Prelude               hiding (Meta)
 
-import           Data.ByteString.Char8         (ByteString)
-import           Data.Text                     (Text)
 import           Data.Time.Clock               (UTCTime)
-import           Data.Word                     (Word64)
 
 -- Do not use explicit imports from this module as the imports can change
 -- from version to version due to changes to the TH code in Persistent.

--- a/smash/src/Cardano/SMASH/DBSync/Metrics.hs
+++ b/smash/src/Cardano/SMASH/DBSync/Metrics.hs
@@ -4,39 +4,66 @@
 module Cardano.SMASH.DBSync.Metrics
   ( Metrics (..)
   , makeMetrics
-  , registerMetricsServer
+  , withMetricSetters
+  , withMetricsServer
   ) where
 
 import           Cardano.Prelude
 
-import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..), registerGauge,
-                    runRegistryT, unRegistryT)
-import           System.Metrics.Prometheus.Metric.Gauge (Gauge)
-import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)
+import           Cardano.Slotting.Slot (SlotNo (..))
 
+import           Cardano.Sync.Types (MetricSetters (..))
+
+import           Ouroboros.Network.Block (BlockNo (..))
+
+import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT (..), registerGauge,
+                   runRegistryT, unRegistryT)
+import           System.Metrics.Prometheus.Http.Scrape (serveMetricsT)
+import           System.Metrics.Prometheus.Metric.Gauge (Gauge)
+import qualified System.Metrics.Prometheus.Metric.Gauge as Gauge
 
 data Metrics = Metrics
-  { mDbHeight :: !Gauge
-  , mNodeHeight :: !Gauge
-  , mQueuePre :: !Gauge
-  , mQueuePost :: !Gauge
-  , mQueuePostWrite :: !Gauge
+  { mNodeBlockHeight :: !Gauge
+  -- ^ The block tip number of the remote node.
+  , mDbQueueLength :: !Gauge
+  -- ^ The number of @DbAction@ remaining for the database.
+  , mDbBlockHeight :: !Gauge
+  -- ^ The block tip number in the database.
+  , mDbSlotHeight :: !Gauge
+  -- ^ The slot tip number in the database.
   }
 
-registerMetricsServer :: Int -> IO (Metrics, Async ())
-registerMetricsServer portNumber =
-  runRegistryT $ do
-    metrics <- makeMetrics
-    registry <- RegistryT ask
-    server <- liftIO . async $ runReaderT (unRegistryT $ serveMetricsT portNumber []) registry
-    pure (metrics, server)
+-- This enables us to be much more flexibile with what we actually measure.
+withMetricSetters :: Int -> (MetricSetters -> IO a) -> IO a
+withMetricSetters prometheusPort action =
+  withMetricsServer prometheusPort $ \metrics -> do
+    action $
+      MetricSetters
+        { metricsSetNodeBlockHeight = \ (BlockNo nodeHeight) ->
+            Gauge.set (fromIntegral nodeHeight) $ mNodeBlockHeight metrics
+        , metricsSetDbQueueLength = \ queuePostWrite ->
+            Gauge.set (fromIntegral queuePostWrite) $ mDbQueueLength metrics
+        , metricsSetDbBlockHeight = \ (BlockNo blockNo) ->
+            Gauge.set (fromIntegral blockNo) $ mDbBlockHeight metrics
+        , metricsSetDbSlotHeight = \ (SlotNo slotNo) ->
+            Gauge.set (fromIntegral slotNo) $ mDbSlotHeight metrics
+        }
+
+withMetricsServer :: Int -> (Metrics -> IO a) -> IO a
+withMetricsServer port action = do
+  -- Using both `RegistryT` and `bracket` here is overkill. Unfortunately the
+  -- Prometheus API requires the use of a `Registry` and this seems to be the
+  -- least sucky way of doing it.
+  (metrics, registry) <- runRegistryT $ (,) <$> makeMetrics <*> RegistryT ask
+  bracket
+     (async $ runReaderT (unRegistryT $ serveMetricsT port []) registry)
+     cancel
+     (const $ action metrics)
 
 makeMetrics :: RegistryT IO Metrics
 makeMetrics =
   Metrics
-    <$> registerGauge "db_block_height" mempty
-    <*> registerGauge "remote_tip_height" mempty
-    <*> registerGauge "action_queue_length_pre" mempty
-    <*> registerGauge "action_queue_length_post" mempty
-    <*> registerGauge "action_queue_length_post_write" mempty
-
+    <$> registerGauge "cardano_db_sync_node_block_height" mempty
+    <*> registerGauge "cardano_db_sync_db_queue_length" mempty
+    <*> registerGauge "cardano_db_sync_db_block_height" mempty
+    <*> registerGauge "cardano_db_sync_db_slot_height" mempty

--- a/smash/src/Cardano/SMASH/DBSyncPlugin.hs
+++ b/smash/src/Cardano/SMASH/DBSyncPlugin.hs
@@ -13,9 +13,7 @@ import           Cardano.BM.Trace                   (Trace, logDebug, logError,
                                                      logInfo)
 
 import           Control.Monad.Logger               (LoggingT)
-import           Control.Monad.Trans.Except.Extra   (firstExceptT, newExceptT,
-                                                     runExceptT)
-import           Control.Monad.Trans.Reader         (ReaderT)
+import           Control.Monad.Trans.Except.Extra   (firstExceptT, newExceptT)
 
 import           Cardano.SMASH.DB                   (DBFail (..),
                                                      DataLayer (..))

--- a/smash/src/Cardano/SMASH/Offline.hs
+++ b/smash/src/Cardano/SMASH/Offline.hs
@@ -14,7 +14,6 @@ import           Cardano.Prelude                  hiding (from, groupBy, on,
 
 import           Cardano.BM.Trace                 (Trace, logInfo, logWarning)
 
-import           Control.Concurrent               (threadDelay)
 import           Control.Monad.Logger             (LoggingT)
 import           Control.Monad.Trans.Except.Extra (handleExceptT, hoistEither,
                                                    left)

--- a/smash/test/MigrationSpec.hs
+++ b/smash/test/MigrationSpec.hs
@@ -7,28 +7,22 @@ module MigrationSpec
 
 import           Cardano.Prelude
 
-import           Control.Monad.Trans.Except.Extra  (left)
-import           Data.Time.Clock.POSIX             (getPOSIXTime)
+import           Control.Monad.Trans.Except.Extra (left)
+import           Data.Time.Clock.POSIX            (getPOSIXTime)
 
-import           Test.Hspec                        (Spec, describe)
-import           Test.Hspec.QuickCheck             (modifyMaxSuccess, prop)
-import           Test.QuickCheck.Monadic           (assert, monadicIO, run)
+import           Test.Hspec                       (Spec, describe)
+import           Test.Hspec.QuickCheck            (modifyMaxSuccess, prop)
+import           Test.QuickCheck.Monadic          (assert, monadicIO, run)
 
-import qualified Cardano.BM.Trace                  as Logging
+import qualified Cardano.BM.Trace                 as Logging
 
 import           Cardano.SMASH.FetchQueue
 import           Cardano.SMASH.Offline
 import           Cardano.SMASH.Types
 
 import           Cardano.SMASH.DB
-import           Cardano.SMASH.DBSync.Db.Insert    (insertPoolMetadataReference)
-import           Cardano.SMASH.DBSync.Db.Migration (SmashLogFileDir (..),
-                                                    SmashMigrationDir (..),
-                                                    runMigrations)
-import           Cardano.SMASH.DBSync.Db.Query     (querySchemaVersion)
-import           Cardano.SMASH.DBSync.Db.Run       (runDbNoLogging)
-import           Cardano.SMASH.DBSync.Db.Schema    (PoolMetadataReference (..),
-                                                    SchemaVersion (..))
+import           Cardano.SMASH.DBSync.Db.Insert   (insertPoolMetadataReference)
+import           Cardano.SMASH.DBSync.Db.Schema   (SchemaVersion (..))
 
 -- | Test spec for smash
 -- SMASHPGPASSFILE=config/pgpass-test ./scripts/postgresql-setup.sh --createdb

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.25.1.yaml
-compiler: ghc-8.6.5
+resolver: lts-17.4
 
-#allow-newer: true
+allow-newer: true
 
 packages:
 - smash
@@ -22,6 +21,161 @@ ghc-options:
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 extra-deps:
+  - Cabal-3.4.0.0
+  - async-timer-0.2.0.0
+  - parsec-3.1.14.0
+  - base16-0.1.2.1
+  - base16-bytestring-1.0.1.0
+  - base58-bytestring-0.1.0
+  - base64-0.4.2
+  - bech32-1.1.0
+  - bech32-th-1.0.2
+  - binary-0.8.7.0
+  - bimap-0.4.0
+  - canonical-json-0.6.0.0
+  - cborg-0.2.4.0
+  - clock-0.8
+  - config-ini-0.2.4.0
+  - connection-0.3.1
+  - containers-0.5.11.0
+  - data-clist-0.1.2.2
+  - dns-3.0.4
+  - generic-monoid-0.1.0.0
+  - generics-sop-0.5.1.0
+  - ghc-byteorder-4.11.0.0.10
+  - gray-code-0.3.1
+  - hedgehog-1.0.2
+  - hedgehog-corpus-0.2.0
+  - hedgehog-quickcheck-0.1.1
+  - hspec-2.7.0
+  - hspec-core-2.7.0
+  - hspec-discover-2.7.0
+  - io-streams-1.5.1.0
+  - io-streams-haproxy-1.0.1.0
+  - katip-0.8.4.0
+  - libsystemd-journal-1.4.4
+  - micro-recursion-schemes-5.0.2.2
+  - moo-1.2
+  - network-3.1.2.1
+  - partial-order-0.2.0.0
+  - prettyprinter-1.7.0
+  - primitive-0.7.1.0
+  - protolude-0.3.0
+  - quiet-0.2
+  - semialign-1.1.0.1
+  - snap-core-1.0.4.1
+  - snap-server-1.1.1.1
+  - sop-core-0.5.0.1
+  - statistics-linreg-0.3
+  - streaming-binary-0.2.2.0
+  - streaming-bytestring-0.2.0
+  - systemd-2.3.0
+  - tasty-hedgehog-1.0.0.2
+  - text-1.2.4.0
+  - text-ansi-0.1.0
+  - text-conversions-0.3.1
+  - text-zipper-0.10.1
+  - th-lift-instances-0.1.14
+  - these-1.1.1.1
+  - time-units-1.0.0
+  - transformers-except-0.1.1
+  - unordered-containers-0.2.12.0
+  - Unique-0.4.7.6
+  - word-wrap-0.4.1
+  - websockets-0.12.6.1
+  - Win32-2.6.2.0
+  - nothunks-0.1.2
+  
+  - git: https://github.com/input-output-hk/cardano-base
+    commit: b364d925e0a72689ecba40dd1f4899f76170b894
+    subdirs:
+    - binary
+    - binary/test
+    - cardano-crypto-class
+    - cardano-crypto-tests
+    - cardano-crypto-praos
+    - slotting
+  
+  - git: https://github.com/input-output-hk/cardano-crypto
+    commit: f73079303f663e028288f9f4a9e08bcca39a923e
+  
+  - git: https://github.com/input-output-hk/cardano-ledger-specs
+    commit: 99e2f2e32ebfca3291fa523ddcae14c8cbb48fa0
+    subdirs:
+    - byron/chain/executable-spec
+    - byron/crypto
+    - byron/crypto/test
+    - byron/ledger/executable-spec
+    - byron/ledger/impl
+    - byron/ledger/impl/test
+    - semantics/executable-spec
+    - semantics/small-steps-test
+    - shelley/chain-and-ledger/dependencies/non-integer
+    - shelley/chain-and-ledger/executable-spec
+    - shelley/chain-and-ledger/shelley-spec-ledger-test
+    - shelley-ma/impl
+  
+  - git: https://github.com/input-output-hk/cardano-node
+    commit: e15515b785f7caae0ae5d997b26d9c4518062c71
+    subdirs:
+    - cardano-api
+    - cardano-api/test
+    - cardano-cli
+    - cardano-config
+    - cardano-node
+    - cardano-node-chairman
+    - hedgehog-extras
+  
+  - git: https://github.com/input-output-hk/cardano-prelude
+    commit: ee4e7b547a991876e6b05ba542f4e62909f4a571
+    subdirs:
+    - cardano-prelude
+    - cardano-prelude-test
+  
+  - git: https://github.com/input-output-hk/cardano-sl-x509
+    commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
+  
+  - git: https://github.com/input-output-hk/goblins
+    commit: cde90a2b27f79187ca8310b6549331e59595e7ba
+  
+  - git: https://github.com/input-output-hk/iohk-monitoring-framework
+    commit: 60b13d80afa266f02f363672950e896ed735e807
+    subdirs:
+    - contra-tracer
+    - iohk-monitoring
+    - plugins/backend-aggregation
+    - plugins/backend-ekg
+    - plugins/backend-monitoring
+    - plugins/backend-trace-forwarder
+    - plugins/scribe-systemd
+    - tracer-transformers
+  
+  - git: https://github.com/input-output-hk/ouroboros-network
+    commit: 96cf17bcc6ea4ef455a19430313ce17d476d62b5
+    subdirs:
+    - io-sim
+    - io-sim-classes
+    - network-mux
+    - ouroboros-consensus
+    - ouroboros-consensus-byron
+    - ouroboros-consensus-cardano
+    - ouroboros-consensus-shelley
+    - ouroboros-network
+    - ouroboros-network-framework
+    - typed-protocols
+    - typed-protocols-examples
+    - Win32-network
+    # Extra packages not used by cardano-node
+    - cardano-client
+    - ntp-client
+    - ouroboros-consensus-mock
+  
+  - git: https://github.com/snoyberg/http-client.git
+    commit: 1a75bdfca014723dd5d40760fad854b3f0f37156
+    subdirs:
+    - http-client
+
+  # Additional deps
   - persistent-2.11.0.1
   - persistent-postgresql-2.11.0.0
   - persistent-template-2.9.1.0
@@ -32,7 +186,7 @@ extra-deps:
   - prometheus-2.2.2
 
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: d5aa846e0751227aa6461084d6ea0567535f752e
+    commit: e8359d608c47709a22a140d9f34c2ede43a67922
     subdirs:
       - cardano-sync
       - cardano-db


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2060

Updating dependencies for `smash` to match the new `db-sync` version so we can add a plugin to the newest version of `db-sync`.

Tested syncing on `mainnet` - `Insert 'Shelley' block pool info: epoch 229, slot 186000, block BlockNo 4947749, global slot 99114000 `