### PR TITLE
[CAD-2060] Bumping dependencies for new db-sync.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,8 +46,8 @@ package ouroboros-consensus-cardano
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-db-sync
-  tag: 6f6e49964385b46620e055dafe38a69c76249f94
-  --sha256: 0m757q430l1x9n9qpai2zk2f9d1hmhlhhny0kxjdimxm9xzlivpn
+  tag: c43a653371ba73ad8e4ececad9ac1b7ad45e2ff5
+  --sha256: 156qfrkhrmqgrsr7cd12k8lxbcdvmcn40p82bbxy6qxdm1kkx45c
   subdir:
     cardano-sync
     cardano-db

--- a/stack.yaml
+++ b/stack.yaml
@@ -89,7 +89,7 @@ extra-deps:
 
   # db-sync dependency
   - git: https://github.com/input-output-hk/cardano-db-sync
-    commit: 6f6e49964385b46620e055dafe38a69c76249f94
+    commit: c43a653371ba73ad8e4ececad9ac1b7ad45e2ff5
     subdirs:
       - cardano-sync
       - cardano-db


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2060

Using latest commit hash, having issues with building `db-sync` when referencing `smash` repo.